### PR TITLE
Typo in index.bs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ wasm-operand-stack := 0x02 i:uleb128
   </tbody>
 </table>
 
-Note: This approach leverages DWARF's vendor extensibility (see 7.1 of [[DWARF]]) to reserve custom DWARF expression opcodes for WebAssembly-specific location descriptions. The encoding provides the basic set of need operators. In the future, it is possible to extend this set with a more compact encoding scheme, as well as adding specific DWARF extensions for a set of commonly used WebAssembly-specific location.
+Note: This approach leverages DWARF's vendor extensibility (see 7.1 of [[DWARF]]) to reserve custom DWARF expression opcodes for WebAssembly-specific location descriptions. The encoding provides the basic set of needed operators. In the future, it is possible to extend this set with a more compact encoding scheme, as well as adding specific DWARF extensions for a set of commonly used WebAssembly-specific location.
 
 Note: The WebAssembly does not impose a limit of the maximum amount of local or globals. It will be a challenge to agree on an encoding scheme to represent WebAssembly locations listed above as registers, as well as documenting this scheme in the DWARF standard.
 

--- a/index.bs
+++ b/index.bs
@@ -111,7 +111,7 @@ The `.debug_line` DWARF section maps instruction pointers to source locations. W
 <div class="example" heading="DW_AT_* Attributes">
 For entities with a single associated code address, DWARF uses the `DW_AT_low_pc` attribute to specify the associated code address value. For WebAssembly, the `DW_AT_low_pc`'s value is a `Code` section-relative instruction offset.
 
-For entities with a single contiguous range of code, DWARF uses a pair of `DW_AT_low_pc` and `DW_AT_high_pc` attributes to specify the associated contiguous range of code address values. For WebAassembly, these attributes are `Code` section-relative instruction offsets.
+For entities with a single contiguous range of code, DWARF uses a pair of `DW_AT_low_pc` and `DW_AT_high_pc` attributes to specify the associated contiguous range of code address values. For WebAssembly, these attributes are `Code` section-relative instruction offsets.
 
 For entities with multiple ranges of code, DWARF uses the `DW_AT_ranges` attribute, which refers to the array located at the `.debug_ranges` section.
 </div>

--- a/index.html
+++ b/index.html
@@ -1485,7 +1485,7 @@ ed_data        ::= b∗:<a href="https://webassembly.github.io/spec/core/binary/
     <a class="self-link" href="#example-962b47d0"></a>
     <div class="marker">EXAMPLE: DW_AT_* Attributes</div>
      For entities with a single associated code address, DWARF uses the <code>DW_AT_low_pc</code> attribute to specify the associated code address value. For WebAssembly, the <code>DW_AT_low_pc</code>'s value is a <code>Code</code> section-relative instruction offset. 
-    <p>For entities with a single contiguous range of code, DWARF uses a pair of <code>DW_AT_low_pc</code> and <code>DW_AT_high_pc</code> attributes to specify the associated contiguous range of code address values. For WebAassembly, these attributes are <code>Code</code> section-relative instruction offsets.</p>
+    <p>For entities with a single contiguous range of code, DWARF uses a pair of <code>DW_AT_low_pc</code> and <code>DW_AT_high_pc</code> attributes to specify the associated contiguous range of code address values. For WebAssembly, these attributes are <code>Code</code> section-relative instruction offsets.</p>
     <p>For entities with multiple ranges of code, DWARF uses the <code>DW_AT_ranges</code> attribute, which refers to the array located at the <code>.debug_ranges</code> section.</p>
    </div>
    <h3 class="heading settled" data-level="2.2" id="DWARF-expressions-and-location-descriptions"><span class="secno">2.2. </span><span class="content">DWARF Expressions and Location Descriptions</span><a class="self-link" href="#DWARF-expressions-and-location-descriptions"></a></h3>


### PR DESCRIPTION
I understand that `index.bs` is the original format, hopefully my change to `index.html` won't mess up regeneration.

- [x] Squash (on merge)